### PR TITLE
TF Hub Colab Demo

### DIFF
--- a/demo/Fairness_Indicators_on_TF_Hub.ipynb
+++ b/demo/Fairness_Indicators_on_TF_Hub.ipynb
@@ -9,7 +9,7 @@
       "source": [
         "# Fairness Indicators on TF-Hub Text Embeddings\n",
         "\n",
-        "In this colab, you will learn how to use Fairness Indicators. Fairness Indicators a suite of tools built on top of [TensorFlow Model Analysis](https://www.tensorflow.org/tfx/model_analysis/get_started) that facilitates evaluation and visualization of fairness metrics on models.\n"
+        "In this colab, you will learn how to use [Fairness Indicators](https://github.com/tensorflow/fairness-indicators). Fairness Indicators is a suite of tools that facilitates evaluation and visualization of fairness metrics on machine learning models. Fairness Indicators is built on top of [TensorFlow Model Analysis](https://www.tensorflow.org/tfx/guide/tfma), TensorFlow's official model evaluation library.\n"
       ]
     },
     {
@@ -22,20 +22,6 @@
         "## Read Me First\n",
         "\n",
         "This colab is presently designed for **Python 2**."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 0,
-      "metadata": {
-        "colab": {},
-        "colab_type": "code",
-        "id": "BAUEkqYlzP3W"
-      },
-      "outputs": [],
-      "source": [
-        "%tensorflow_version 1.x\n",
-        "!pip install fairness-indicator"
       ]
     },
     {
@@ -68,6 +54,20 @@
       "metadata": {
         "colab": {},
         "colab_type": "code",
+        "id": "BAUEkqYlzP3W"
+      },
+      "outputs": [],
+      "source": [
+        "%tensorflow_version 1.x\n",
+        "!pip install fairness-indicators"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
         "id": "B8dlyTyiTe-9"
       },
       "outputs": [],
@@ -76,8 +76,6 @@
         "import tempfile\n",
         "import apache_beam as beam\n",
         "from datetime import datetime\n",
-        "import numpy as np\n",
-        "import pandas as pd\n",
         "import tensorflow_hub as hub\n",
         "import tensorflow as tf\n",
         "import tensorflow_model_analysis as tfma\n",
@@ -129,7 +127,7 @@
         "id": "4sZag6SFaMIp"
       },
       "source": [
-        "In this exercise, you'll work with the [Civil Comments dataset](https://www.kaggle.com/c/jigsaw-unintended-bias-in-toxicity-classification), approximately 2 million public comments made public by the [Civil Comments platform](https://github.com/reaktivstudios/civil-comments) in 2017 for ongoing research. This effort was sponsored by Jigsaw, who have hosted competitions on Kaggle to help classify toxic comments as well as minimize unintended model bias.\n",
+        "In this exercise, we'll work with the [Civil Comments dataset](https://www.kaggle.com/c/jigsaw-unintended-bias-in-toxicity-classification), approximately 2 million public comments made public by the [Civil Comments platform](https://github.com/reaktivstudios/civil-comments) in 2017 for ongoing research. This effort was sponsored by Jigsaw, who have hosted competitions on Kaggle to help classify toxic comments as well as minimize unintended model bias.\n",
         "\n",
         "Each individual text comment in the dataset has a toxicity label, with the label being 1 if the comment is toxic and 0 if the comment is non-toxic. Within the data, a subset of comments are labeled with a variety of identity attributes, including categories for gender, sexual orientation, religion, and race or ethnicity."
       ]
@@ -177,12 +175,27 @@
       "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
-        "id": "mfbgerCsEOmN"
+        "id": "zz1NLR5Uu3oQ"
       },
       "source": [
-        "# Creating a Pipeline to Compare Text Embeddings\n",
+        "# Creating a TensorFlow Model Analysis Pipeline\n",
         "\n",
-        "Let's compare the performance of models built with different text embeddings. First, we need to create a model."
+        "The Fairness Indicators library operates on [TensorFlow Model Analysis (TFMA) models](https://www.tensorflow.org/tfx/model_analysis/get_started). TFMA models wrap [TensorFlow models](https://www.tensorflow.org/guide/estimator) with additional functionality to evaluate and visualize their results. The actual evaluation occurs inside of an [Apache Beam pipeline](https://beam.apache.org/documentation/programming-guide/).\n",
+        "\n",
+        "So we need to...\n",
+        "1. build a TensorFlow model\n",
+        "2. build a TFMA model on top of the TensorFlow model\n",
+        "3. run the model analysis in a Beam pipeline"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "lOUjSzEvxO81"
+      },
+      "source": [
+        "## 1) Build a TensorFlow Model"
       ]
     },
     {
@@ -192,16 +205,8 @@
         "id": "5dIo0yXvQdjo"
       },
       "source": [
-        "## Input Function"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
-        "id": "jKYGRHaCSsie"
-      },
-      "source": [
+        "### Define an Input Function\n",
+        "\n",
         "TensorFlow parses features from data using [`FixedLenFeature`](https://www.tensorflow.org/api_docs/python/tf/io/FixedLenFeature) and [`VarLenFeature`](https://www.tensorflow.org/api_docs/python/tf/io/VarLenFeature). So to allow TensorFlow to parse our data, we will need to map out our input feature, output feature, and any slicing features that we will want to analyze via Fairness Indicators."
       ]
     },
@@ -269,7 +274,7 @@
         "id": "23i7M_w_bvQu"
       },
       "source": [
-        "## Classifier\n",
+        "### Train a Classifier\n",
         "\n",
         "For each text embedding, we will train a **[DNN Classifier](https://www.tensorflow.org/api_docs/python/tf/estimator/DNNClassifier)**.\n",
         "\n",
@@ -312,16 +317,30 @@
       "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
-        "id": "onSL_CMbWHBB"
+        "id": "Nmi2aniNxmfo"
       },
       "source": [
-        "## Fairness Indicators in TFMA\n",
-        "\n",
-        "To analyze our model's results with **Fairness Indicators**, we need to add Fairness Indicators as a callback that is returned after model execution.\n",
-        "\n",
-        "To do this, we use [TFMA](https://www.tensorflow.org/tfx/model_analysis/get_started)'s **[`EvalSharedModel`](https://www.tensorflow.org/tfx/model_analysis/api_docs/python/tfma/types/EvalSharedModel)** class. `EvalSharedModel` builds on TFMA's **[`EvalSavedModel`](https://g3doc.corp.google.com/intelligence/lantern/tensorflow_model_analysis/g3doc/faq.md#what-is-an-evalsavedmodel)**, so we first need to convert our `tf.estimator` to an `EvalSavedModel`.\n",
-        "\n",
-        "EvalSavedModels parse [`tf.Examples`](https://www.tensorflow.org/tutorials/load_data/tfrecord#tfexample) with an **`eval_input_receiver_fn`**, so we also need to create that."
+        "## 2) Build a TFMA model"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "saqHENye6tIH"
+      },
+      "source": [
+        "### Define an Input Function"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "hnoxsKIDXAOY"
+      },
+      "source": [
+        "TFMA represents datasets as [`tf.Examples`](https://www.tensorflow.org/tutorials/load_data/tfrecord#tfexample), which it parses with [`EvalInputReceivers`](https://github.com/tensorflow/model-analysis/blob/master/tensorflow_model_analysis/eval_saved_model/export.py#L42). Refer to [Getting Started with TensorFlow Model Analysis](https://www.tensorflow.org/tfx/model_analysis/get_started#modify_an_existing_model) for more info on creating `EvalInputReceivers`."
       ]
     },
     {
@@ -330,22 +349,10 @@
       "metadata": {
         "colab": {},
         "colab_type": "code",
-        "id": "GRiumqP-WM-j"
+        "id": "DU6BEc41xuHs"
       },
       "outputs": [],
       "source": [
-        "def eval_model_with_fairness_indicators(classifier):\n",
-        "  eval_saved_model_path = tfma.export.export_eval_savedmodel(\n",
-        "      estimator=classifier,\n",
-        "      export_dir_base=os.path.join(BASE_DIR, 'tfma_eval_model'),\n",
-        "      eval_input_receiver_fn=eval_input_receiver_fn)\n",
-        "  fairness_indicator_callback = tfma.post_export_metrics.fairness_indicators(\n",
-        "                                    thresholds=[0.1, 0.3, 0.5, 0.7, 0.9],\n",
-        "                                    labels_key=LABEL)\n",
-        "  return tfma.default_eval_shared_model(\n",
-        "        eval_saved_model_path=eval_saved_model_path,\n",
-        "        add_metrics_callbacks=[fairness_indicator_callback])\n",
-        "  \n",
         "def eval_input_receiver_fn():\n",
         "  \"\"\"Create a tfma.export.EvalInputReceiver to parse input features.\"\"\"\n",
         "  serialized_tf_example = tf.compat.v1.placeholder(\n",
@@ -363,14 +370,72 @@
       "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
+        "id": "_8O8gh-i9xfK"
+      },
+      "source": [
+        "### Compose a TFMA Model"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "0W5VYoVdW9Tp"
+      },
+      "source": [
+        "TFMA represents models with its **[`EvalSharedModel`](https://github.com/tensorflow/model-analysis/blob/master/tensorflow_model_analysis/types.py#L172)** class, which accepts a list of metrics to evaluate and visualize. TFMA represents metrics as callbacks which are computed after the model is exported - hence, the name **[`post_export_metrics`](https://github.com/tensorflow/model-analysis/blob/master/tensorflow_model_analysis/post_export_metrics/post_export_metrics.py)**. The metric provided by the Fairness Indicators library is **`post_export_metrics.fairness_indicators`**.\n",
+        "\n",
+        "`EvalSharedModel` is actually a thin wrapper around TFMA's **[`EvalSavedModel`](https://github.com/tensorflow/model-analysis/blob/master/tensorflow_model_analysis/eval_saved_model/load.py#L54)** class. To create an `EvalSavedModel`, we need to pass in a TensorFlow model and an `EvalInputReceiver`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 0,
+      "metadata": {
+        "colab": {},
+        "colab_type": "code",
+        "id": "I67Zm4Dc9UE2"
+      },
+      "outputs": [],
+      "source": [
+        "def create_tfma_model(classifier, eval_input_receiver_fn, metric_callbacks):\n",
+        "\n",
+        "  # create EvalSavedModel\n",
+        "  eval_saved_model_path = tfma.export.export_eval_savedmodel(\n",
+        "      estimator=classifier,\n",
+        "      export_dir_base=os.path.join(BASE_DIR, 'tfma_eval_model'),\n",
+        "      eval_input_receiver_fn=eval_input_receiver_fn)\n",
+        "\n",
+        "  # create EvalSharedModel\n",
+        "  return tfma.default_eval_shared_model(\n",
+        "        eval_saved_model_path=eval_saved_model_path,\n",
+        "        add_metrics_callbacks=metric_callbacks)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
         "id": "1HbCbLLbWZLT"
       },
       "source": [
-        "## TFMA - Apache Beam\n",
+        "## 3) Get Evaluation Results in Apache Beam"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "geCqkTyMW5Nr"
+      },
+      "source": [
+        "Our [Beam pipeline]((https://beam.apache.org/documentation/programming-guide/) will have two steps. The first step is to read in the data in a TF-compatible format - we can use [`beam.io.ReadFromTFRecord`](https://beam.apache.org/releases/pydoc/2.15.0/apache_beam.io.tfrecordio.html#apache_beam.io.tfrecordio.ReadFromTFRecord) for that.\n",
         "\n",
-        "Now that we have our evaluation model with a callback to the Fairness Indicators results, we can create a function that computes and returns those results!\n",
+        "The second step is to evaluate the TFMA results. We use TFMA's [`ExtractEvaluateAndWriteResults`](https://www.tensorflow.org/tfx/model_analysis/api_docs/python/tfma/ExtractEvaluateAndWriteResults) API, a [`PTransform`](https://beam.apache.org/documentation/programming-guide/#transforms) that takes in an `EvalSharedModel`, computes metrics for the slices specified in `slice_spec`, and writes them to an `output_path`.\n",
         "\n",
-        "TFMA is built on the **[Apache Beam](https://beam.apache.org/documentation/programming-guide/)**, data processing framework. TFMA provides the [`ExtractEvaluateAndWriteResults`](https://www.tensorflow.org/tfx/model_analysis/api_docs/python/tfma/ExtractEvaluateAndWriteResults) API to use as a [`PTransform`](https://beam.apache.org/documentation/programming-guide/#transforms) in Beam pipelines. Check the [Get Started with TensorFlow Model Analysis](https://www.tensorflow.org/tfx/model_analysis/get_started) tutorial for more information."
+        "[`slice_spec`](https://www.tensorflow.org/tfx/tutorials/model_analysis/tfma_basic#slicing_and_dicing) is how TFMA decides how to group the data. In this case study, the slices refer to different identity groups. We'll show you how to create a `slice_spec` in the next section.\n",
+        "\n",
+        "Check the [Get Started with TensorFlow Model Analysis](https://www.tensorflow.org/tfx/model_analysis/get_started) tutorial for more information on how to integrate TFMA with Beam."
       ]
     },
     {
@@ -383,15 +448,12 @@
       },
       "outputs": [],
       "source": [
-        "def get_eval_result(embedding, eval_shared_model, eval_result_path):\n",
-        "  slice_spec = [tfma.slicer.SingleSliceSpec()]\n",
-        "  for identity in IDENTITY_TERMS:\n",
-        "    slice_spec.append(tfma.slicer.SingleSliceSpec(columns=[identity]))\n",
+        "def get_eval_result(input_file, eval_shared_model, slice_spec, eval_result_path):\n",
         "  with beam.Pipeline() as pipeline:\n",
         "    _ = (\n",
         "        pipeline\n",
         "        | 'ReadFromTFRecord' \u003e\u003e beam.io.ReadFromTFRecord(\n",
-        "            file_pattern=validate_tf_file)\n",
+        "            file_pattern=input_file)\n",
         "        | 'ExtractEvaluateAndWriteResults' \u003e\u003e\n",
         "        tfma.ExtractEvaluateAndWriteResults(\n",
         "                  eval_shared_model=eval_shared_model,\n",
@@ -409,9 +471,7 @@
         "id": "wM-faceoCPqg"
       },
       "source": [
-        "# Evaluate Embedding\n",
-        "\n",
-        "Now that we have all the steps in place - training a model on an embedding, converting it to a TFMA format, and computing Fairness Indicators on it - we can make a pipeline to compare Fairness Indicators on different embeddings!"
+        "# Putting it all Together"
       ]
     },
     {
@@ -424,10 +484,10 @@
       },
       "outputs": [],
       "source": [
-        "def embedding_eval_result(embedding):\n",
+        "def embedding_fairness_result(embedding):\n",
         "\n",
-        "  # First, we use the train_classifier() function we created earlier to train a\n",
-        "  # basic classifier using our chosen embedding.\n",
+        "  # First, we use our train_classifier() function to train a basic classifier\n",
+        "  # with our chosen embedding.\n",
         "  print(\"Training classifier for \" + embedding)\n",
         "  classifier = train_classifier(embedding)\n",
         "\n",
@@ -435,18 +495,32 @@
         "  train_eval_result = classifier.evaluate(input_fn=lambda: input_fn(validate_tf_file))\n",
         "  print('Validation set accuracy for {}: {accuracy}'.format(embedding, **train_eval_result))\n",
         "\n",
-        "  # We then use our eval_model_with_fairness_indicators() function to convert\n",
-        "  # the model to a TFMA EvalSharedModel with a callback to Fairness Indicators.\n",
-        "  eval_shared_model = eval_model_with_fairness_indicators(classifier)\n",
+        "  # We then create a fairness_indicators callback to use in our TFMA model.\n",
+        "  # `labels_key` is the target feature (\"toxicity\" in our case).\n",
+        "  # `thresholds` are the values of the target feature at which to measure fairness metrics.\n",
+        "  fairness_indicator_callback = tfma.post_export_metrics.fairness_indicators(\n",
+        "                                    thresholds=[0.1, 0.3, 0.5, 0.7, 0.9],\n",
+        "                                    labels_key=LABEL)\n",
         "\n",
-        "  # We also need to create a unique path to store our results for this\n",
-        "  # embedding.\n",
+        "  # We then use our create_tfma_model() function, which converts our classifier\n",
+        "  # to a TFMA EvalSharedModel that outputs Fairness Indicators.\n",
+        "  eval_shared_model = create_tfma_model(classifier, eval_input_receiver_fn,\n",
+        "                                        [fairness_indicator_callback])\n",
+        "\n",
+        "  # We select the slices we want to compute Fairness results for.\n",
+        "  # In this case, we use the same identity terms that you selected at the\n",
+        "  # beginning of the colab.\n",
+        "  slice_spec = [tfma.slicer.SingleSliceSpec()]\n",
+        "  for identity in IDENTITY_TERMS:\n",
+        "    slice_spec.append(tfma.slicer.SingleSliceSpec(columns=[identity]))\n",
+        "\n",
+        "  # We also need to create a unique path to store our results for this embedding.\n",
         "  embedding_name = embedding.split('/')[-2]\n",
         "  eval_result_path = os.path.join(BASE_DIR, 'eval_result', embedding_name)\n",
         "\n",
         "  # Finally, we use our get_eval_result() function to compute and return the\n",
         "  # Fairness Indicators results!\n",
-        "  eval_result = get_eval_result(embedding, eval_shared_model, eval_result_path)\n",
+        "  eval_result = get_eval_result(validate_tf_file, eval_shared_model, slice_spec, eval_result_path)\n",
         "  return eval_result"
       ]
     },
@@ -464,27 +538,10 @@
       "cell_type": "markdown",
       "metadata": {
         "colab_type": "text",
-        "id": "LGXCFtScblYt"
-      },
-      "source": [
-        "## Text Embeddings\n",
-        "\n",
-        "**[TF-Hub](https://www.tensorflow.org/hub)** provides several **text embeddings**. These embeddings will serve as the feature column for our different models. For this Colab, we use the following embeddings:\n",
-        "\n",
-        "* [**random-nnlm-en-dim128**](https://tfhub.dev/google/random-nnlm-en-dim128/1): random text embeddings, this serves as a convenient baseline.\n",
-        "* [**nnlm-en-dim128**](https://tfhub.dev/google/nnlm-en-dim128/1): a text embedding based on [A Neural Probabilistic Language Model](http://www.jmlr.org/papers/volume3/bengio03a/bengio03a.pdf). \n",
-        "* [**universal-sentence-encoder**](https://tfhub.dev/google/universal-sentence-encoder/2): a text embedding based on [Universal Sentence Encoder](https://arxiv.org/pdf/1803.11175.pdf).\n",
-        "\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "colab_type": "text",
         "id": "8AvInTNt8Gyn"
       },
       "source": [
-        "## Fairness Indicators Results"
+        "## Fairness Indicators Metrics"
       ]
     },
     {
@@ -494,16 +551,60 @@
         "id": "jiLg5ikCzFR-"
       },
       "source": [
-        "Refer [here](https://github.com/tensorflow/fairness-indicators) for more information on analyzing data with Fairness Indicators. Below are some of the available metrics.\n",
+        "Refer [here](https://github.com/tensorflow/fairness-indicators) for more information on Fairness Indicators. Below are some of the available metrics.\n",
         "\n",
         "* [Negative Rate, False Negative Rate (FNR), and True Negative Rate (TNR)](https://en.wikipedia.org/wiki/False_positives_and_false_negatives#False_positive_and_false_negative_rates)\n",
         "* [Positive Rate, False Positive Rate (FPR), and True Positive Rate (TPR)](https://en.wikipedia.org/wiki/False_positives_and_false_negatives#False_positive_and_false_negative_rates)\n",
         "* [Accuracy](https://www.tensorflow.org/api_docs/python/tf/keras/metrics/Accuracy)\n",
         "* [Precision and Recall](https://en.wikipedia.org/wiki/Precision_and_recall)\n",
         "* [Precision-Recall AUC](https://www.tensorflow.org/api_docs/python/tf/keras/metrics/AUC)\n",
-        "* [ROC AUC](https://en.wikipedia.org/wiki/Receiver_operating_characteristic#Area_under_the_curve)\n",
+        "* [ROC AUC](https://en.wikipedia.org/wiki/Receiver_operating_characteristic#Area_under_the_curve)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "LGXCFtScblYt"
+      },
+      "source": [
+        "## Text Embeddings"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "1CI-1M5qXGjG"
+      },
+      "source": [
+        "**[TF-Hub](https://www.tensorflow.org/hub)** provides several **text embeddings**. These embeddings will serve as the feature column for our different models. For this Colab, we use the following embeddings:\n",
         "\n",
-        "Note that the `widget_view.render_fairness_indicator()` cells may need to be run twice for the visualization to be displayed."
+        "* [**random-nnlm-en-dim128**](https://tfhub.dev/google/random-nnlm-en-dim128/1): random text embeddings, this serves as a convenient baseline.\n",
+        "* [**nnlm-en-dim128**](https://tfhub.dev/google/nnlm-en-dim128/1): a text embedding based on [A Neural Probabilistic Language Model](http://www.jmlr.org/papers/volume3/bengio03a/bengio03a.pdf). \n",
+        "* [**universal-sentence-encoder**](https://tfhub.dev/google/universal-sentence-encoder/2): a text embedding based on [Universal Sentence Encoder](https://arxiv.org/pdf/1803.11175.pdf)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "xxq97Qt7itVL"
+      },
+      "source": [
+        "## Fairness Indicator Resutls"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "colab_type": "text",
+        "id": "27FX15awixuK"
+      },
+      "source": [
+        "For each of the above embeddings, we will compute fairness indicators with our `embedding_fairness_result` pipeline, and then render the results in the Fairness Indicator UI widget with `widget_view.render_fairness_indicator`.\n",
+        "\n",
+        "Note that the `widget_view.render_fairness_indicator` cells may need to be run twice for the visualization to be displayed."
       ]
     },
     {
@@ -526,7 +627,7 @@
       },
       "outputs": [],
       "source": [
-        "eval_result_random_nnlm = embedding_eval_result('https://tfhub.dev/google/random-nnlm-en-dim128/1')"
+        "eval_result_random_nnlm = embedding_fairness_result('https://tfhub.dev/google/random-nnlm-en-dim128/1')"
       ]
     },
     {
@@ -562,7 +663,7 @@
       },
       "outputs": [],
       "source": [
-        "eval_result_nnlm = embedding_eval_result('https://tfhub.dev/google/nnlm-en-dim128/1')"
+        "eval_result_nnlm = embedding_fairness_result('https://tfhub.dev/google/nnlm-en-dim128/1')"
       ]
     },
     {
@@ -598,7 +699,7 @@
       },
       "outputs": [],
       "source": [
-        "eval_result_use = embedding_eval_result('https://tfhub.dev/google/universal-sentence-encoder/2')"
+        "eval_result_use = embedding_fairness_result('https://tfhub.dev/google/universal-sentence-encoder/2')"
       ]
     },
     {
@@ -632,7 +733,9 @@
   ],
   "metadata": {
     "colab": {
-      "collapsed_sections": [],
+      "collapsed_sections": [
+        "5dIo0yXvQdjo"
+      ],
       "name": "Fairness Indicators on TF-Hub Text Embeddings - External",
       "private_outputs": true,
       "provenance": []


### PR DESCRIPTION
Improvements
* Added more structure to the TFMA pipeline, splitting it into 3 parts (1. building TF model, 2. building TFMA model, 3. running Beam pipeline)
* Add more explanation of how TFMA works, including more links and explaining post_export_metrics and slice_spec
* Add a lot more links to documentation
* Detangle TFMA and Fairness Indicators sections so that readers can understand TFMA before learning Fairness Indicators
* Rename 'embedding_eval_result' to 'embedding_fairness_result'
* Remove unneeded imports

Bug Fixes:
* fix typo in fairness-indicators pip install