### PR TITLE
In preparation for the combined evaluator/validator, the input/output specs are being moved out of tfma.EvalConfig. This CL updates the calls to run_model_analysis to pass the parameters directly.

### DIFF
--- a/fairness_indicators/example_model.py
+++ b/fairness_indicators/example_model.py
@@ -134,14 +134,9 @@ def evaluate_model(classifier, validate_tf_file, tfma_eval_result_path,
       eval_saved_model_path=tfma_export_dir,
       add_metrics_callbacks=add_metrics_callbacks)
 
-  eval_config = tfma.EvalConfig(
-      input_data_specs=[tfma.InputDataSpec(location=validate_tf_file)],
-      model_specs=[tfma.ModelSpec(location=tfma_export_dir)],
-      output_data_specs=[
-          tfma.OutputDataSpec(default_location=tfma_eval_result_path)
-      ],
-      slicing_specs=[s.to_proto() for s in slice_spec])
-
   # Run the fairness evaluation.
   tfma.run_model_analysis(
-      eval_config=eval_config, eval_shared_model=eval_shared_model)
+      eval_shared_model=eval_shared_model,
+      data_location=validate_tf_file,
+      output_path=tfma_eval_result_path,
+      slice_spec=slice_spec)

--- a/tensorboard_plugin/tensorboard_plugin_fairness_indicators/plugin_test.py
+++ b/tensorboard_plugin/tensorboard_plugin_fairness_indicators/plugin_test.py
@@ -145,16 +145,11 @@ class PluginTest(tf.test.TestCase):
         self._makeExample(age=5.0, language="hindi", label=1.0)
     ]
     data_location = self._writeTFExamplesToTFRecords(examples)
-    eval_config = tfma.EvalConfig(
-        input_data_specs=[tfma.InputDataSpec(location=data_location)],
-        model_specs=[tfma.ModelSpec(location=model_location)],
-        output_data_specs=[
-            tfma.OutputDataSpec(default_location=self._eval_result_output_dir)
-        ])
     _ = tfma.run_model_analysis(
-        eval_config=eval_config,
         eval_shared_model=tfma.default_eval_shared_model(
-            eval_saved_model_path=model_location, example_weight_key="age"))
+            eval_saved_model_path=model_location, example_weight_key="age"),
+        data_location=data_location,
+        output_path=self._eval_result_output_dir)
 
     response = self._server.get(
         "/data/plugin/fairness_indicators/get_evaluation_result?run=.")


### PR DESCRIPTION
In preparation for the combined evaluator/validator, the input/output specs are being moved out of tfma.EvalConfig. This CL updates the calls to run_model_analysis to pass the parameters directly.
