### PR TITLE
Comment: remove %tensorflow_version if running in jupyter

### DIFF
--- a/fairness_indicators/examples/Facessd_Fairness_Indicators_Example_Colab.ipynb
+++ b/fairness_indicators/examples/Facessd_Fairness_Indicators_Example_Colab.ipynb
@@ -72,7 +72,7 @@
       },
       "outputs": [],
       "source": [
-        "%tensorflow_version 2.x\n",
+        "%tensorflow_version 2.x\t#delete this line if running in jupyter\n",
         "import os\n",
         "import tempfile\n",
         "import apache_beam as beam\n",

--- a/fairness_indicators/examples/Fairness_Indicators_Example_Colab.ipynb
+++ b/fairness_indicators/examples/Fairness_Indicators_Example_Colab.ipynb
@@ -77,7 +77,6 @@
       },
       "outputs": [],
       "source": [
-        "%tensorflow_version 2.x\n",
         "import os\n",
         "import tempfile\n",
         "import apache_beam as beam\n",

--- a/fairness_indicators/examples/Fairness_Indicators_TensorBoard_Plugin_Example_Colab.ipynb
+++ b/fairness_indicators/examples/Fairness_Indicators_TensorBoard_Plugin_Example_Colab.ipynb
@@ -76,7 +76,7 @@
       },
       "outputs": [],
       "source": [
-        "%tensorflow_version 1.x\n",
+        "%tensorflow_version 1.x\t#delete this line if running in jupyter\n",
         "\n",
         "import datetime\n",
         "import os\n",

--- a/fairness_indicators/examples/Fairness_Indicators_on_TF_Hub_Text_Embeddings.ipynb
+++ b/fairness_indicators/examples/Fairness_Indicators_on_TF_Hub_Text_Embeddings.ipynb
@@ -45,7 +45,6 @@
       },
       "outputs": [],
       "source": [
-        "%tensorflow_version 2.x\n",
         "import os\n",
         "import tempfile\n",
         "import apache_beam as beam\n",


### PR DESCRIPTION
Comment: remove %tensorflow_version if running in jupyter

%tensorflow_version is only supported in colab, not jupyter.
