### PR TITLE
Fix breaking colab due to wrong TF version and imports

### DIFF
--- a/fairness_indicators/examples/Fairness_Indicators_Example_Colab.ipynb
+++ b/fairness_indicators/examples/Fairness_Indicators_Example_Colab.ipynb
@@ -64,7 +64,11 @@
       },
       "outputs": [],
       "source": [
-        "!pip install fairness-indicators"
+        "!pip install fairness-indicators \\\n",
+        "  \"absl-py==0.8.0\" \\\n",
+        "  \"pyarrow==0.15.1\" \\\n",
+        "  \"apache-beam==2.17.0\" \\\n",
+        "  \"avro-python3==1.9.1\""
       ]
     },
     {
@@ -77,6 +81,7 @@
       },
       "outputs": [],
       "source": [
+        "%tensorflow_version 2.x\t#delete this line if running in jupyter\n",
         "import os\n",
         "import tempfile\n",
         "import apache_beam as beam\n",

--- a/fairness_indicators/examples/Fairness_Indicators_on_TF_Hub_Text_Embeddings.ipynb
+++ b/fairness_indicators/examples/Fairness_Indicators_on_TF_Hub_Text_Embeddings.ipynb
@@ -32,7 +32,11 @@
       },
       "outputs": [],
       "source": [
-        "!pip install fairness-indicators"
+        "!pip install fairness-indicators \\\n",
+        "  \"absl-py==0.8.0\" \\\n",
+        "  \"pyarrow==0.15.1\" \\\n",
+        "  \"apache-beam==2.17.0\" \\\n",
+        "  \"avro-python3==1.9.1\""
       ]
     },
     {
@@ -45,6 +49,7 @@
       },
       "outputs": [],
       "source": [
+        "%tensorflow_version 2.x\t#delete this line if running in jupyter\n",
         "import os\n",
         "import tempfile\n",
         "import apache_beam as beam\n",


### PR DESCRIPTION
Fix breaking colab due to wrong TF version and imports

A previous commit removed the line needed to ensure the colab ran in TF2. This commit fixes that.
