### PR TITLE
Replacing pip installs for the default pre-installed TF2: %tensorflow_version 2.x

### DIFF
--- a/fairness_indicators/examples/Fairness_Indicators_Lineage_Case_Study.ipynb
+++ b/fairness_indicators/examples/Fairness_Indicators_Lineage_Case_Study.ipynb
@@ -98,21 +98,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -q -U \\\n",
-        "  tensorflow==2.1.0 \\\n",
-        "  tfx==0.21.2 \\\n",
-        "  tensorflow-model-analysis==0.21.6 \\\n",
-        "  tensorflow_data_validation==0.21.5 \\\n",
-        "  tensorflow-metadata==0.21.1 \\\n",
-        "  tensorflow-transform==0.21.2 \\\n",
-        "  ml-metadata==0.21.2 \\\n",
-        "  tfx-bsl==0.21.4 \\\n",
-        "  pyarrow==0.15.1 \\\n",
-        "  absl-py==0.8.1 \\\n",
-        "  avro-python3==1.8.2\n",
-        "\n",
-        " # If prompted, please restart the Colab environment after the pip installs\n",
-        " # as you might run into import errors."
+        "%tensorflow_version 2.x"
       ]
     },
     {


### PR DESCRIPTION
Replacing pip installs for the default pre-installed TF2: %tensorflow_version 2.x
