### PR TITLE
Replace fairness_indicators.examples with fairness_indicators.documen…

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Non-Tensorflow Models
 
 ## Examples
 
-The [examples](https://github.com/tensorflow/fairness-indicators/tree/master/fairness_indicators/examples) directory contains several examples.
+The [examples](https://github.com/tensorflow/fairness-indicators/tree/master/fairness_indicators/documentation/examples) directory contains several examples.
 
 * [Fairness_Indicators_Example_Colab.ipynb](https://github.com/tensorflow/fairness-indicators/blob/master/fairness_indicators/documentation/examples/Fairness_Indicators_Example_Colab.ipynb) gives an overview of Fairness Indicators in [TensorFlow Model Analysis](https://www.tensorflow.org/tfx/guide/tfma) and how to use it with a real dataset. This notebook also goes over [TensorFlow Data Validation](https://www.tensorflow.org/tfx/data_validation/get_started) and [What-If Tool](https://pair-code.github.io/what-if-tool/), two tools for analyzing TensorFlow models that are packaged with Fairness Indicators.
 * [Fairness_Indicators_on_TF_Hub.ipynb](https://github.com/tensorflow/fairness-indicators/blob/master/fairness_indicators/documentation/examples/Fairness_Indicators_on_TF_Hub_Text_Embeddings.ipynb) demonstrates how to use Fairness Indicators to compare models trained on different [text embeddings](https://en.wikipedia.org/wiki/Word_embedding). This notebook uses text embeddings from [TensorFlow Hub](https://www.tensorflow.org/hub), TensorFlow's library to publish, discover, and reuse model components.

--- a/fairness_indicators/documentation/__init__.py
+++ b/fairness_indicators/documentation/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2019 Google LLC. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/fairness_indicators/documentation/examples/Fairness_Indicators_Example_Colab.ipynb
+++ b/fairness_indicators/documentation/examples/Fairness_Indicators_Example_Colab.ipynb
@@ -91,7 +91,7 @@
         "import tensorflow_data_validation as tfdv\n",
         "from tensorflow_model_analysis.addons.fairness.post_export_metrics import fairness_indicators\n",
         "from tensorflow_model_analysis.addons.fairness.view import widget_view\n",
-        "from fairness_indicators.examples import util\n",
+        "from fairness_indicators.documentation.examples import util\n",
         "\n",
         "from witwidget.notebook.visualization import WitConfigBuilder\n",
         "from witwidget.notebook.visualization import WitWidget\n"

--- a/fairness_indicators/documentation/examples/Fairness_Indicators_on_TF_Hub_Text_Embeddings.ipynb
+++ b/fairness_indicators/documentation/examples/Fairness_Indicators_on_TF_Hub_Text_Embeddings.ipynb
@@ -60,7 +60,7 @@
         "from tensorflow_model_analysis.addons.fairness.view import widget_view\n",
         "from tensorflow_model_analysis.addons.fairness.post_export_metrics import fairness_indicators\n",
         "from fairness_indicators import example_model\n",
-        "from fairness_indicators.examples import util"
+        "from fairness_indicators.documentation.examples import util"
       ]
     },
     {


### PR DESCRIPTION
…tation.examples

fairness_indicators.examples is a deprecated path that has been replaced with airness_indicators.documentation.examples

PiperOrigin-RevId: 327864525