### PR TITLE
Change methods not using its bound instance to `staticmethods`

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,8 @@
+version = 1
+
+[[analyzers]]
+name = "python"
+enabled = true
+
+  [analyzers.meta]
+  runtime_version = "3.x.x"

--- a/fairness_indicators/documentation/examples/util_test.py
+++ b/fairness_indicators/documentation/examples/util_test.py
@@ -30,7 +30,8 @@ from google.protobuf import text_format
 
 class UtilTest(tf.test.TestCase):
 
-  def _create_example_tfrecord(self):
+  @staticmethod
+  def _create_example_tfrecord():
     example = text_format.Parse(
         """
         features {
@@ -96,7 +97,8 @@ class UtilTest(tf.test.TestCase):
         """, tf.train.Example())
     return [example, empty_comment_example]
 
-  def _write_tf_records(self, examples):
+  @staticmethod
+  def _write_tf_records(examples):
     filename = os.path.join(tempfile.mkdtemp(), 'input.tfrecord')
     with tf.io.TFRecordWriter(filename) as writer:
       for e in examples:
@@ -144,7 +146,8 @@ class UtilTest(tf.test.TestCase):
         }
         """, tf.train.Example()))
 
-  def _create_example_csv(self, use_fake_embedding=False):
+  @staticmethod
+  def _create_example_csv(use_fake_embedding=False):
     header = [
         'comment_text',
         'toxicity',
@@ -236,7 +239,8 @@ class UtilTest(tf.test.TestCase):
     ]
     return [header, example, empty_comment_example]
 
-  def _write_csv(self, examples):
+  @staticmethod
+  def _write_csv(examples):
     filename = os.path.join(tempfile.mkdtemp(), 'input.csv')
     with open(filename, 'w', newline='') as csvfile:
       csvwriter = csv.writer(csvfile, delimiter=',')

--- a/fairness_indicators/documentation/tutorials/util_test.py
+++ b/fairness_indicators/documentation/tutorials/util_test.py
@@ -30,7 +30,8 @@ from google.protobuf import text_format
 
 class UtilTest(tf.test.TestCase):
 
-  def _create_example_tfrecord(self):
+  @staticmethod
+  def _create_example_tfrecord():
     example = text_format.Parse(
         """
         features {
@@ -96,7 +97,8 @@ class UtilTest(tf.test.TestCase):
         """, tf.train.Example())
     return [example, empty_comment_example]
 
-  def _write_tf_records(self, examples):
+  @staticmethod
+  def _write_tf_records(examples):
     filename = os.path.join(tempfile.mkdtemp(), 'input.tfrecord')
     with tf.io.TFRecordWriter(filename) as writer:
       for e in examples:
@@ -144,7 +146,8 @@ class UtilTest(tf.test.TestCase):
         }
         """, tf.train.Example()))
 
-  def _create_example_csv(self, use_fake_embedding=False):
+  @staticmethod
+  def _create_example_csv(use_fake_embedding=False):
     header = [
         'comment_text',
         'toxicity',
@@ -236,7 +239,8 @@ class UtilTest(tf.test.TestCase):
     ]
     return [header, example, empty_comment_example]
 
-  def _write_csv(self, examples):
+  @staticmethod
+  def _write_csv(examples):
     filename = os.path.join(tempfile.mkdtemp(), 'input.csv')
     with open(filename, 'w', newline='') as csvfile:
       csvwriter = csv.writer(csvfile, delimiter=',')

--- a/fairness_indicators/example_model_test.py
+++ b/fairness_indicators/example_model_test.py
@@ -49,7 +49,8 @@ class ExampleModelTest(tf.test.TestCase):
         self._base_dir, 'train',
         datetime.datetime.now().strftime('%Y%m%d-%H%M%S'))
 
-  def _create_example(self, comment_text, label, slice_value):
+  @staticmethod
+  def _create_example(comment_text, label, slice_value):
     example = tf.train.Example()
     example.features.feature[TEXT_FEATURE].bytes_list.value[:] = [
         six.ensure_binary(comment_text, 'utf8')

--- a/fairness_indicators/remediation/weight_utils_test.py
+++ b/fairness_indicators/remediation/weight_utils_test.py
@@ -17,7 +17,8 @@ EvalResult = collections.namedtuple('EvalResult', ['slicing_metrics'])
 
 class WeightUtilsTest(tf.test.TestCase):
 
-  def create_eval_result(self):
+  @staticmethod
+  def create_eval_result():
     return EvalResult(slicing_metrics=[
         ((), {
             '': {
@@ -58,7 +59,8 @@ class WeightUtilsTest(tf.test.TestCase):
           }),
     ])
 
-  def create_bounded_result(self):
+  @staticmethod
+  def create_bounded_result():
     return EvalResult(slicing_metrics=[
         ((), {
             '': {

--- a/tensorboard_plugin/tensorboard_plugin_fairness_indicators/plugin.py
+++ b/tensorboard_plugin/tensorboard_plugin_fairness_indicators/plugin.py
@@ -71,7 +71,8 @@ class FairnessIndicatorsPlugin(base_plugin.TBPlugin):
             self._serve_vulcanized_js,
     }
 
-  def frontend_metadata(self):
+  @staticmethod
+  def frontend_metadata():
     return base_plugin.FrontendMetadata(
         es_module_path='/index.js',
         disable_reload=False,
@@ -93,7 +94,8 @@ class FairnessIndicatorsPlugin(base_plugin.TBPlugin):
             FairnessIndicatorsPlugin.plugin_name))
 
   @wrappers.Request.application
-  def _serve_js(self, request):
+  @staticmethod
+  def _serve_js(request):
     filepath = os.path.join(os.path.dirname(__file__), 'static', 'index.js')
     with open(filepath) as infile:
       contents = infile.read()
@@ -101,7 +103,8 @@ class FairnessIndicatorsPlugin(base_plugin.TBPlugin):
         request, contents, content_type='application/javascript')
 
   @wrappers.Request.application
-  def _serve_vulcanized_js(self, request):
+  @staticmethod
+  def _serve_vulcanized_js(request):
     with open(_TEMPLATE_LOCATION) as infile:
       contents = infile.read()
     return http_util.Respond(
@@ -129,7 +132,8 @@ class FairnessIndicatorsPlugin(base_plugin.TBPlugin):
       logging.info('Error while fetching evaluation data, %s', error)
     return http_util.Respond(request, data, content_type='application/json')
 
-  def _get_output_file_format(self, evaluation_output_path):
+  @staticmethod
+  def _get_output_file_format(evaluation_output_path):
     file_format = os.path.splitext(evaluation_output_path)[1]
     if file_format:
       return file_format[1:]

--- a/tensorboard_plugin/tensorboard_plugin_fairness_indicators/plugin_test.py
+++ b/tensorboard_plugin/tensorboard_plugin_fairness_indicators/plugin_test.py
@@ -92,7 +92,8 @@ class PluginTest(tf.test.TestCase):
         writer.write(example.SerializeToString())
     return data_location
 
-  def _makeExample(self, age, language, label):
+  @staticmethod
+  def _makeExample(age, language, label):
     example = tf.train.Example()
     example.features.feature["age"].float_list.value[:] = [age]
     example.features.feature["language"].bytes_list.value[:] = [


### PR DESCRIPTION
This pull request fixes some of the quality issues raised by DeepSource on my fork of this repository.

Summary of fixes:

- Change methods not using its bound instance to `staticmethods`

You can see all the issues raised by DeepSource [here](https://deepsource.io/gh/HarshCasper/fairness-indicators/).

These Issues were fixed manually as suggested by DeepSource

### Using DeepSource to continuously analyze your repository

- Merge this PR. I have included a `.deepsource.toml` in this PR, which you can use to configure your analysis settings.
- Install DeepSource on your repository [here](https://deepsource.io/signup).
- Activate analysis [here](https://deepsource.io/gh/tensorflow/fairness-indicators).

If you do not want to use DeepSource to continuously analyze this repo, I'll remove the `.deepsource.toml` from this PR and you can merge the rest of the fixes.