### PR TITLE
[*.py] Rename "Arguments:" to "Args:"

### DIFF
--- a/tensorboard_plugin/tensorboard_plugin_fairness_indicators/summary_v2.py
+++ b/tensorboard_plugin/tensorboard_plugin_fairness_indicators/summary_v2.py
@@ -26,7 +26,7 @@ from tensorboard.compat import tf2 as tf
 def FairnessIndicators(eval_result_output_dir, step=None, description=None):
   """Write a Fairness Indicators summary.
 
-  Arguments:
+  Args:
     eval_result_output_dir: Directory output created by
       tfma.model_eval_lib.ExtractEvaluateAndWriteResults API, which contains
       'metrics' file having MetricsForSlice results.


### PR DESCRIPTION
I've written custom parsers and emitters for everything from docstrings to classes and functions. However, I recently came across an issue with the TensorFlow codebase: inconsistent use of `Args:` and `Arguments:` in its docstrings. It is easy enough to extend my parsers to support both variants, however it looks like `Arguments:` is wrong anyway, as per:

  - https://google.github.io/styleguide/pyguide.html#doc-function-args @ [`ddccc0f`](https://github.com/google/styleguide/blob/ddccc0f/pyguide.md)

  - https://chromium.googlesource.com/chromiumos/docs/+/master/styleguide/python.md#describing-arguments-in-docstrings @ [`9fc0fc0`](https://chromium.googlesource.com/chromiumos/docs/+/9fc0fc0/styleguide/python.md)

  - https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html @ [`c0ae8e3`](https://github.com/sphinx-contrib/napoleon/blob/c0ae8e3/docs/source/example_google.rst)

Therefore, only `Args:` is valid. This PR replaces them throughout the codebase.

PS: For related PRs, see tensorflow/tensorflow/pull/45420