### PR TITLE
Fixing broken link in Wiki_case_study.ipynb

### DIFF
--- a/g3doc/tutorials/Fairness_Indicators_TFCO_Wiki_Case_Study.ipynb
+++ b/g3doc/tutorials/Fairness_Indicators_TFCO_Wiki_Case_Study.ipynb
@@ -312,7 +312,7 @@
         "id": "Cn5zbgp-Ws9F"
       },
       "source": [
-        "Finally, we identify comments related to certain sensitive topic groups. We consider a subset of the \u003ca href=\"https://github.com/conversationai/unintended-ml-bias-analysis/blob/master/unintended_ml_bias/bias_madlibs_data/adjectives_people.txt\"\u003eidentity terms\u003c/a\u003e provided with the dataset and group them into\n",
+        "Finally, we identify comments related to certain sensitive topic groups. We consider a subset of the \u003ca href=\"https://github.com/conversationai/unintended-ml-bias-analysis/blob/main/archive/unintended_ml_bias/bias_madlibs_data/adjectives_people.txt\"\u003eidentity terms\u003c/a\u003e provided with the dataset and group them into\n",
         "four broad topic groups: *sexuality*, *gender identity*, *religion*, and *race*."
       ]
     },


### PR DESCRIPTION
Updated the broken link for `identity terms` in [this section](https://www.tensorflow.org/responsible_ai/fairness_indicators/tutorials/Fairness_Indicators_TFCO_Wiki_Case_Study#load_and_pre-process_dataset).