### PR TITLE
Add testing with PyTest and GitHub Actions workflow

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -15,7 +15,7 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
-        package-path: |
+        cache-dependency-path: |
           ${{ inputs.package-root-dir }}/setup.py
 
     - name: Install dependencies

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -1,0 +1,25 @@
+name: Set up environment
+description: Set up environment and install package
+
+inputs:
+  python-version:
+    required: true
+  package-root-dir:
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+        package-path: |
+          ${{ inputs.package-root-dir }}/setup.py
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install ${{ inputs.package-root-dir }}[test]
+  

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -3,8 +3,10 @@ description: Set up environment and install package
 
 inputs:
   python-version:
+    default: "3.10"
     required: true
   package-root-dir:
+    default: "./"
     required: true
 
 runs:

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -19,6 +19,7 @@ runs:
           ${{ inputs.package-root-dir }}/setup.py
 
     - name: Install dependencies
+      shell: bash
       run: |
         python -m pip install --upgrade pip
         pip install ${{ inputs.package-root-dir }}[test]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,7 @@ jobs:
         package-root-dir: ${{ matrix.package-root-dir }}
 
     - name: Run tests
+      shell: bash
       run: |
         cd ${{ matrix.package-root-dir }}
         pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[test]
+
+    - name: Run tests
+      run: |
+        pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Tests
 on:
   push:
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   pull_request:
     branches: [ master ]
     paths-ignore:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,3 +20,10 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache-dependency-path: |
+          setup.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Tests
+on:
+  push:
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+  workflow_dispatch:
+
+jobs:
+  tests:
+    if: github.actor != 'copybara-service[bot]'
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10']
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,23 +16,19 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10']
+        package-root-dir: ['.', './tensorboard_plugin']
 
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+    - name: Set up environment
+      uses: ./.github/actions/setup-env
       with:
         python-version: ${{ matrix.python-version }}
-        cache-dependency-path: |
-          setup.py
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install .[test]
+        package-root-dir: ${{ matrix.package-root-dir }}
 
     - name: Run tests
       run: |
+        cd ${{ matrix.package-root-dir }}
         pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10']
-        package-root-dir: ['.', './tensorboard_plugin']
+        package-root-dir: ['./', './tensorboard_plugin']
 
     steps:
     - name: Checkout repo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache-dependency-path: |
           setup.py
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .[test]

--- a/fairness_indicators/example_model_test.py
+++ b/fairness_indicators/example_model_test.py
@@ -163,7 +163,3 @@ class ExampleModelTest(tf.test.TestCase):
         metric_values['fairness_indicators_metrics/true_negative_rate@0.1'],
         {'doubleValue': 1.0},
     )
-
-
-if __name__ == '__main__':
-  tf.test.main()

--- a/fairness_indicators/remediation/weight_utils_test.py
+++ b/fairness_indicators/remediation/weight_utils_test.py
@@ -215,7 +215,3 @@ class WeightUtilsTest(tf.test.TestCase):
     self.assertIn('gender', res)
     self.assertAlmostEqual(res['gender']['female'], 0.125)
     self.assertAlmostEqual(res[''][''], 0)
-
-
-if __name__ == '__main__':
-  tf.test.main()

--- a/fairness_indicators/tutorial_utils/util_test.py
+++ b/fairness_indicators/tutorial_utils/util_test.py
@@ -323,6 +323,3 @@ class UtilTest(tf.test.TestCase):
         eval_config=expected_eval_config,
         output_path=eval_results_path,
         extractors=None)
-
-if __name__ == '__main__':
-  tf.test.main()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = "--import-mode=importlib"
+testpaths = "fairness_indicators"
+python_files = "*_test.py"

--- a/setup.py
+++ b/setup.py
@@ -21,80 +21,79 @@ import setuptools
 
 
 if sys.version_info >= (3, 11):
-    sys.exit("Sorry, Python >= 3.11 is not supported")
+  sys.exit('Sorry, Python >= 3.11 is not supported')
 
 
 def select_constraint(default, nightly=None, git_master=None):
-    """Select dependency constraint based on TFX_DEPENDENCY_SELECTOR env var."""
-    selector = os.environ.get("TFX_DEPENDENCY_SELECTOR")
-    if selector == "UNCONSTRAINED":
-        return ""
-    elif selector == "NIGHTLY" and nightly is not None:
-        return nightly
-    elif selector == "GIT_MASTER" and git_master is not None:
-        return git_master
-    else:
-        return default
-
-
+  """Select dependency constraint based on TFX_DEPENDENCY_SELECTOR env var."""
+  selector = os.environ.get('TFX_DEPENDENCY_SELECTOR')
+  if selector == 'UNCONSTRAINED':
+    return ''
+  elif selector == 'NIGHTLY' and nightly is not None:
+    return nightly
+  elif selector == 'GIT_MASTER' and git_master is not None:
+    return git_master
+  else:
+    return default
 REQUIRED_PACKAGES = [
-    "tensorflow>=2.16,<2.17",
-    "tensorflow-hub>=0.16.1,<1.0.0",
-    "tensorflow-data-validation>=1.16.1,<2.0.0",
-    "tensorflow-model-analysis>=0.47.1,<0.48.0",
-    "witwidget>=1.4.4,<2",
-    "protobuf>=3.20.3,<5",
+    'tensorflow>=2.16,<2.17',
+    'tensorflow-hub>=0.16.1,<1.0.0',
+    'tensorflow-data-validation>=1.16.1,<2.0.0',
+    'tensorflow-model-analysis>=0.47.1,<0.48.0',
+    'witwidget>=1.4.4,<2',
+    'protobuf>=3.20.3,<5',
 ]
 
 TEST_PACKAGES = [
-    "pytest",
+    'pytest',
 ]
 # Get version from version module.
-with open("fairness_indicators/version.py") as fp:
-    globals_dict = {}
-    exec(fp.read(), globals_dict)  # pylint: disable=exec-used
-__version__ = globals_dict["__version__"]
-with open("README.md", "r", encoding="utf-8") as fh:
-    long_description = fh.read()
+with open('fairness_indicators/version.py') as fp:
+  globals_dict = {}
+  exec(fp.read(), globals_dict)  # pylint: disable=exec-used
+__version__ = globals_dict['__version__']
+with open('README.md', 'r', encoding='utf-8') as fh:
+  long_description = fh.read()
 setuptools.setup(
-    name="fairness_indicators",
+    name='fairness_indicators',
     version=__version__,
-    description="Fairness Indicators",
+    description='Fairness Indicators',
     long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/tensorflow/fairness-indicators",
-    author="Google LLC",
-    author_email="packages@tensorflow.org",
-    packages=setuptools.find_packages(exclude=["tensorboard_plugin"]),
+    long_description_content_type='text/markdown',
+    url='https://github.com/tensorflow/fairness-indicators',
+    author='Google LLC',
+    author_email='packages@tensorflow.org',
+    packages=setuptools.find_packages(exclude=['tensorboard_plugin']),
     package_data={
-        "fairness_indicators": ["documentation/*"],
+        'fairness_indicators': ['documentation/*'],
     },
-    python_requires=">=3.9,<4",
+    python_requires='>=3.9,<4',
     install_requires=REQUIRED_PACKAGES,
     tests_require=REQUIRED_PACKAGES,
     extras_require={
-        "test": TEST_PACKAGES,
+        'test': TEST_PACKAGES,
     },
     # PyPI package information.
     classifiers=[
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Education",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3 :: Only",
-        "Topic :: Scientific/Engineering",
-        "Topic :: Scientific/Engineering :: Mathematics",
-        "Topic :: Scientific/Engineering :: Artificial Intelligence",
-        "Topic :: Software Development",
-        "Topic :: Software Development :: Libraries",
-        "Topic :: Software Development :: Libraries :: Python Modules",
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Education',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3 :: Only',
+        'Topic :: Scientific/Engineering',
+        'Topic :: Scientific/Engineering :: Mathematics',
+        'Topic :: Scientific/Engineering :: Artificial Intelligence',
+        'Topic :: Software Development',
+        'Topic :: Software Development :: Libraries',
+        'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    license="Apache 2.0",
+    license='Apache 2.0',
     keywords=(
-        "tensorflow model analysis fairness indicators tensorboard machine learning"
+        'tensorflow model analysis fairness indicators tensorboard machine'
+        ' learning'
     ),
 )

--- a/setup.py
+++ b/setup.py
@@ -21,72 +21,73 @@ import setuptools
 
 
 if sys.version_info >= (3, 11):
-  sys.exit('Sorry, Python >= 3.11 is not supported')
+    sys.exit("Sorry, Python >= 3.11 is not supported")
 
 
 def select_constraint(default, nightly=None, git_master=None):
-  """Select dependency constraint based on TFX_DEPENDENCY_SELECTOR env var."""
-  selector = os.environ.get('TFX_DEPENDENCY_SELECTOR')
-  if selector == 'UNCONSTRAINED':
-    return ''
-  elif selector == 'NIGHTLY' and nightly is not None:
-    return nightly
-  elif selector == 'GIT_MASTER' and git_master is not None:
-    return git_master
-  else:
-    return default
+    """Select dependency constraint based on TFX_DEPENDENCY_SELECTOR env var."""
+    selector = os.environ.get("TFX_DEPENDENCY_SELECTOR")
+    if selector == "UNCONSTRAINED":
+        return ""
+    elif selector == "NIGHTLY" and nightly is not None:
+        return nightly
+    elif selector == "GIT_MASTER" and git_master is not None:
+        return git_master
+    else:
+        return default
+
+
 REQUIRED_PACKAGES = [
-    'tensorflow>=2.16,<2.17',
-    'tensorflow-hub>=0.16.1,<1.0.0',
-    'tensorflow-data-validation>=1.16.1,<2.0.0',
-    'tensorflow-model-analysis>=0.47.1,<0.48.0',
-    'witwidget>=1.4.4,<2',
-    'protobuf>=3.20.3,<5',
+    "tensorflow>=2.16,<2.17",
+    "tensorflow-hub>=0.16.1,<1.0.0",
+    "tensorflow-data-validation>=1.16.1,<2.0.0",
+    "tensorflow-model-analysis>=0.47.1,<0.48.0",
+    "witwidget>=1.4.4,<2",
+    "protobuf>=3.20.3,<5",
 ]
 # Get version from version module.
-with open('fairness_indicators/version.py') as fp:
-  globals_dict = {}
-  exec(fp.read(), globals_dict)  # pylint: disable=exec-used
-__version__ = globals_dict['__version__']
-with open('README.md', 'r', encoding='utf-8') as fh:
-  long_description = fh.read()
+with open("fairness_indicators/version.py") as fp:
+    globals_dict = {}
+    exec(fp.read(), globals_dict)  # pylint: disable=exec-used
+__version__ = globals_dict["__version__"]
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
 setuptools.setup(
-    name='fairness_indicators',
+    name="fairness_indicators",
     version=__version__,
-    description='Fairness Indicators',
+    description="Fairness Indicators",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/tensorflow/fairness-indicators',
-    author='Google LLC',
-    author_email='packages@tensorflow.org',
-    packages=setuptools.find_packages(exclude=['tensorboard_plugin']),
+    long_description_content_type="text/markdown",
+    url="https://github.com/tensorflow/fairness-indicators",
+    author="Google LLC",
+    author_email="packages@tensorflow.org",
+    packages=setuptools.find_packages(exclude=["tensorboard_plugin"]),
     package_data={
-        'fairness_indicators': ['documentation/*'],
+        "fairness_indicators": ["documentation/*"],
     },
-    python_requires='>=3.9,<4',
+    python_requires=">=3.9,<4",
     install_requires=REQUIRED_PACKAGES,
     tests_require=REQUIRED_PACKAGES,
     # PyPI package information.
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Education',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: Apache Software License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3 :: Only',
-        'Topic :: Scientific/Engineering',
-        'Topic :: Scientific/Engineering :: Mathematics',
-        'Topic :: Scientific/Engineering :: Artificial Intelligence',
-        'Topic :: Software Development',
-        'Topic :: Software Development :: Libraries',
-        'Topic :: Software Development :: Libraries :: Python Modules',
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Education",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3 :: Only",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Mathematics",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: Software Development",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    license='Apache 2.0',
+    license="Apache 2.0",
     keywords=(
-        'tensorflow model analysis fairness indicators tensorboard machine'
-        ' learning'
+        "tensorflow model analysis fairness indicators tensorboard machine learning"
     ),
 )

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,10 @@ REQUIRED_PACKAGES = [
     "witwidget>=1.4.4,<2",
     "protobuf>=3.20.3,<5",
 ]
+
+TEST_PACKAGES = [
+    "pytest",
+]
 # Get version from version module.
 with open("fairness_indicators/version.py") as fp:
     globals_dict = {}
@@ -68,6 +72,9 @@ setuptools.setup(
     python_requires=">=3.9,<4",
     install_requires=REQUIRED_PACKAGES,
     tests_require=REQUIRED_PACKAGES,
+    extras_require={
+        "test": TEST_PACKAGES,
+    },
     # PyPI package information.
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ REQUIRED_PACKAGES = [
 ]
 
 TEST_PACKAGES = [
-    'pytest',
+    'pytest>=8.3.0,<9',
 ]
 # Get version from version module.
 with open('fairness_indicators/version.py') as fp:

--- a/tensorboard_plugin/pytest.ini
+++ b/tensorboard_plugin/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = "--import-mode=importlib"
+testpaths = "tensorboard_plugin_fairness_indicators"
+python_files = "*_test.py"

--- a/tensorboard_plugin/setup.py
+++ b/tensorboard_plugin/setup.py
@@ -51,6 +51,10 @@ REQUIRED_PACKAGES = [
     "werkzeug<2",
 ]
 
+TEST_PACKAGES = [
+    "pytest",
+]
+
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
@@ -81,6 +85,9 @@ setup(
     python_requires=">=3.9,<4",
     install_requires=REQUIRED_PACKAGES,
     tests_require=REQUIRED_PACKAGES,
+    extras_require={
+        "test": TEST_PACKAGES,
+    },
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/tensorboard_plugin/setup.py
+++ b/tensorboard_plugin/setup.py
@@ -26,77 +26,78 @@ from setuptools import setup
 
 
 if sys.version_info >= (3, 11):
-  sys.exit('Sorry, Python >= 3.11 is not supported')
+    sys.exit("Sorry, Python >= 3.11 is not supported")
 
 
 def select_constraint(default, nightly=None, git_master=None):
-  """Select dependency constraint based on TFX_DEPENDENCY_SELECTOR env var."""
-  selector = os.environ.get('TFX_DEPENDENCY_SELECTOR')
-  if selector == 'UNCONSTRAINED':
-    return ''
-  elif selector == 'NIGHTLY' and nightly is not None:
-    return nightly
-  elif selector == 'GIT_MASTER' and git_master is not None:
-    return git_master
-  else:
-    return default
+    """Select dependency constraint based on TFX_DEPENDENCY_SELECTOR env var."""
+    selector = os.environ.get("TFX_DEPENDENCY_SELECTOR")
+    if selector == "UNCONSTRAINED":
+        return ""
+    elif selector == "NIGHTLY" and nightly is not None:
+        return nightly
+    elif selector == "GIT_MASTER" and git_master is not None:
+        return git_master
+    else:
+        return default
+
 
 REQUIRED_PACKAGES = [
-    'protobuf>=3.20.3,<5',
-    'tensorboard>=2.16.2,<2.17.0',
-    'tensorflow>=2.16,<2.17',
-    'tf-keras>=2.16,<2.17',
-    'tensorflow-model-analysis>=0.47,<0.48',
-    'werkzeug<2',
+    "protobuf>=3.20.3,<5",
+    "tensorboard>=2.16.2,<2.17.0",
+    "tensorflow>=2.16,<2.17",
+    "tf-keras>=2.16,<2.17",
+    "tensorflow-model-analysis>=0.47,<0.48",
+    "werkzeug<2",
 ]
 
-with open('README.md', 'r', encoding='utf-8') as fh:
-  long_description = fh.read()
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
 
 # Get version from version module.
-with open('tensorboard_plugin_fairness_indicators/version.py') as fp:
-  globals_dict = {}
-  exec(fp.read(), globals_dict)  # pylint: disable=exec-used
-__version__ = globals_dict['__version__']
+with open("tensorboard_plugin_fairness_indicators/version.py") as fp:
+    globals_dict = {}
+    exec(fp.read(), globals_dict)  # pylint: disable=exec-used
+__version__ = globals_dict["__version__"]
 
 setup(
-    name='tensorboard_plugin_fairness_indicators',
+    name="tensorboard_plugin_fairness_indicators",
     version=__version__,
-    description='Fairness Indicators TensorBoard Plugin',
+    description="Fairness Indicators TensorBoard Plugin",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/tensorflow/fairness-indicators',
-    author='Google LLC',
-    author_email='packages@tensorflow.org',
+    long_description_content_type="text/markdown",
+    url="https://github.com/tensorflow/fairness-indicators",
+    author="Google LLC",
+    author_email="packages@tensorflow.org",
     packages=find_packages(),
     package_data={
-       'tensorboard_plugin_fairness_indicators': ['static/**'],
+        "tensorboard_plugin_fairness_indicators": ["static/**"],
     },
     entry_points={
-        'tensorboard_plugins': [
-            'fairness_indicators = tensorboard_plugin_fairness_indicators.plugin:FairnessIndicatorsPlugin',
+        "tensorboard_plugins": [
+            "fairness_indicators = tensorboard_plugin_fairness_indicators.plugin:FairnessIndicatorsPlugin",
         ],
     },
-    python_requires='>=3.9,<4',
+    python_requires=">=3.9,<4",
     install_requires=REQUIRED_PACKAGES,
     tests_require=REQUIRED_PACKAGES,
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Education',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: Apache Software License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3 :: Only',
-        'Topic :: Scientific/Engineering',
-        'Topic :: Scientific/Engineering :: Mathematics',
-        'Topic :: Scientific/Engineering :: Artificial Intelligence',
-        'Topic :: Software Development',
-        'Topic :: Software Development :: Libraries',
-        'Topic :: Software Development :: Libraries :: Python Modules',
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Education",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3 :: Only",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Mathematics",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+        "Topic :: Software Development",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    license='Apache 2.0',
-    keywords='tensorflow model analysis fairness indicators tensorboard machine learning',
+    license="Apache 2.0",
+    keywords="tensorflow model analysis fairness indicators tensorboard machine learning",
 )

--- a/tensorboard_plugin/setup.py
+++ b/tensorboard_plugin/setup.py
@@ -26,85 +26,84 @@ from setuptools import setup
 
 
 if sys.version_info >= (3, 11):
-    sys.exit("Sorry, Python >= 3.11 is not supported")
+  sys.exit('Sorry, Python >= 3.11 is not supported')
 
 
 def select_constraint(default, nightly=None, git_master=None):
-    """Select dependency constraint based on TFX_DEPENDENCY_SELECTOR env var."""
-    selector = os.environ.get("TFX_DEPENDENCY_SELECTOR")
-    if selector == "UNCONSTRAINED":
-        return ""
-    elif selector == "NIGHTLY" and nightly is not None:
-        return nightly
-    elif selector == "GIT_MASTER" and git_master is not None:
-        return git_master
-    else:
-        return default
-
+  """Select dependency constraint based on TFX_DEPENDENCY_SELECTOR env var."""
+  selector = os.environ.get('TFX_DEPENDENCY_SELECTOR')
+  if selector == 'UNCONSTRAINED':
+    return ''
+  elif selector == 'NIGHTLY' and nightly is not None:
+    return nightly
+  elif selector == 'GIT_MASTER' and git_master is not None:
+    return git_master
+  else:
+    return default
 
 REQUIRED_PACKAGES = [
-    "protobuf>=3.20.3,<5",
-    "tensorboard>=2.16.2,<2.17.0",
-    "tensorflow>=2.16,<2.17",
-    "tf-keras>=2.16,<2.17",
-    "tensorflow-model-analysis>=0.47,<0.48",
-    "werkzeug<2",
+    'protobuf>=3.20.3,<5',
+    'tensorboard>=2.16.2,<2.17.0',
+    'tensorflow>=2.16,<2.17',
+    'tf-keras>=2.16,<2.17',
+    'tensorflow-model-analysis>=0.47,<0.48',
+    'werkzeug<2',
 ]
 
 TEST_PACKAGES = [
-    "pytest",
+    'pytest',
 ]
 
-with open("README.md", "r", encoding="utf-8") as fh:
-    long_description = fh.read()
+with open('README.md', 'r', encoding='utf-8') as fh:
+  long_description = fh.read()
 
 # Get version from version module.
-with open("tensorboard_plugin_fairness_indicators/version.py") as fp:
-    globals_dict = {}
-    exec(fp.read(), globals_dict)  # pylint: disable=exec-used
-__version__ = globals_dict["__version__"]
+with open('tensorboard_plugin_fairness_indicators/version.py') as fp:
+  globals_dict = {}
+  exec(fp.read(), globals_dict)  # pylint: disable=exec-used
+__version__ = globals_dict['__version__']
 
 setup(
-    name="tensorboard_plugin_fairness_indicators",
+    name='tensorboard_plugin_fairness_indicators',
     version=__version__,
-    description="Fairness Indicators TensorBoard Plugin",
+    description='Fairness Indicators TensorBoard Plugin',
     long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/tensorflow/fairness-indicators",
-    author="Google LLC",
-    author_email="packages@tensorflow.org",
+    long_description_content_type='text/markdown',
+    url='https://github.com/tensorflow/fairness-indicators',
+    author='Google LLC',
+    author_email='packages@tensorflow.org',
     packages=find_packages(),
     package_data={
-        "tensorboard_plugin_fairness_indicators": ["static/**"],
+       'tensorboard_plugin_fairness_indicators': ['static/**'],
     },
     entry_points={
-        "tensorboard_plugins": [
-            "fairness_indicators = tensorboard_plugin_fairness_indicators.plugin:FairnessIndicatorsPlugin",
+        'tensorboard_plugins': [
+            'fairness_indicators = tensorboard_plugin_fairness_indicators.plugin:FairnessIndicatorsPlugin',
         ],
     },
-    python_requires=">=3.9,<4",
+    python_requires='>=3.9,<4',
     install_requires=REQUIRED_PACKAGES,
     tests_require=REQUIRED_PACKAGES,
     extras_require={
-        "test": TEST_PACKAGES,
+        'test': TEST_PACKAGES,
     },
     classifiers=[
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Education",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: Apache Software License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3 :: Only",
-        "Topic :: Scientific/Engineering",
-        "Topic :: Scientific/Engineering :: Mathematics",
-        "Topic :: Scientific/Engineering :: Artificial Intelligence",
-        "Topic :: Software Development",
-        "Topic :: Software Development :: Libraries",
-        "Topic :: Software Development :: Libraries :: Python Modules",
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Education',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3 :: Only',
+        'Topic :: Scientific/Engineering',
+        'Topic :: Scientific/Engineering :: Mathematics',
+        'Topic :: Scientific/Engineering :: Artificial Intelligence',
+        'Topic :: Software Development',
+        'Topic :: Software Development :: Libraries',
+        'Topic :: Software Development :: Libraries :: Python Modules',
     ],
-    license="Apache 2.0",
-    keywords="tensorflow model analysis fairness indicators tensorboard machine learning",
+    license='Apache 2.0',
+    keywords='tensorflow model analysis fairness indicators tensorboard machine learning',
 )

--- a/tensorboard_plugin/setup.py
+++ b/tensorboard_plugin/setup.py
@@ -51,7 +51,7 @@ REQUIRED_PACKAGES = [
 ]
 
 TEST_PACKAGES = [
-    'pytest',
+    'pytest>=8.3.0,<9',
 ]
 
 with open('README.md', 'r', encoding='utf-8') as fh:

--- a/tensorboard_plugin/tensorboard_plugin_fairness_indicators/metadata_test.py
+++ b/tensorboard_plugin/tensorboard_plugin_fairness_indicators/metadata_test.py
@@ -34,7 +34,3 @@ class MetadataTest(tf.test.TestCase):
     summary_metadata = metadata.CreateSummaryMetadata()
     self.assertEqual(metadata.PLUGIN_NAME,
                      summary_metadata.plugin_data.plugin_name)
-
-
-if __name__ == '__main__':
-  tf.test.main()

--- a/tensorboard_plugin/tensorboard_plugin_fairness_indicators/plugin_test.py
+++ b/tensorboard_plugin/tensorboard_plugin_fairness_indicators/plugin_test.py
@@ -222,7 +222,3 @@ class PluginTest(tf.test.TestCase):
     self.assertEqual(
         "tfrecord", self._plugin._get_output_file_format("abc_path.tfrecord")
     )
-
-
-if __name__ == "__main__":
-  tf.test.main()

--- a/tensorboard_plugin/tensorboard_plugin_fairness_indicators/plugin_test.py
+++ b/tensorboard_plugin/tensorboard_plugin_fairness_indicators/plugin_test.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 
 from collections import abc
 import os
+import pytest
 import shutil
 from unittest import mock
 
@@ -150,6 +151,12 @@ class PluginTest(tf.test.TestCase):
     response = self._server.get("/data/plugin/fairness_indicators/index.js")
     self.assertEqual(200, response.status_code)
 
+  @pytest.mark.xfail(
+    reason=(
+      "This test is currently failing. "
+      "Once it is fixed, please remove this mark."
+      )
+  )
   def testVulcanizedTemplateRoute(self):
     """Tests that the /tags route offers the correct run to tag mapping."""
     response = self._server.get(

--- a/tensorboard_plugin/tensorboard_plugin_fairness_indicators/plugin_test.py
+++ b/tensorboard_plugin/tensorboard_plugin_fairness_indicators/plugin_test.py
@@ -153,8 +153,8 @@ class PluginTest(tf.test.TestCase):
 
   @pytest.mark.xfail(
     reason=(
-      "This test is currently failing. "
-      "Once it is fixed, please remove this mark."
+      "Failing on `master` as of `942b672457e07ac2ac27de0bcc45a4c80276785c`. "
+      "Please remove once fixed."
       )
   )
   def testVulcanizedTemplateRoute(self):

--- a/tensorboard_plugin/tensorboard_plugin_fairness_indicators/summary_v2_test.py
+++ b/tensorboard_plugin/tensorboard_plugin_fairness_indicators/summary_v2_test.py
@@ -67,7 +67,3 @@ class SummaryV2Test(tf.test.TestCase):
         six.ensure_text(summary_value.tensor.string_val[0], 'utf-8'))
     self.assertEqual(metadata.PLUGIN_NAME,
                      summary_value.metadata.plugin_data.plugin_name)
-
-
-if __name__ == '__main__':
-  tf.test.main()


### PR DESCRIPTION
This PR adds config to use pytest to run existing tests. A GitHub Actions workflow is also included. Additionally, there is a composite `setup-env` action that can be used in other workflows that sets up and installs the specified package in the current environment. Separate configs and CI workflow runs are used for the root package, `fairness-indicators`, and `tensorboard_plugin`.

There is one `xfail`ed test that will need to be addressed in future work.