### PR TITLE
Ci build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     needs: [build]
     environment:
       name: pypi
-      url: https://pypi.org/p/tensorflow-fairness-indicators/
+      url: https://test.pypi.org/p/ajf-test-fairness-indicators
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,4 +101,4 @@ jobs:
         with:
           packages_dir: wheels/
           repository_url: https://test.pypi.org/legacy/
-          verify-metadata: false
+          verify_metadata: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,54 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11"]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build fairness-indicators
+      id: build-fairness-indicators
+      uses: ./.github/reusable-build
+      with:
+        python-version: ${{ matrix.python-version }}
+        upload-artifact: true
+
+  upload_to_pypi:
+    name: Upload to PyPI
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'release' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch')
+    needs: [build]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tensorflow-fairness-indicators/
+    permissions:
+      id-token: write
+    steps:
+      - name: Retrieve wheels
+        uses: actions/download-artifact@v4.1.8
+        with:
+          merge-multiple: true
+          path: wheels
+
+      - name: List the build artifacts
+        run: |
+          ls -lAs wheels/
+
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1.9
+        with:
+          packages_dir: wheels/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
   upload_to_pypi:
     name: Upload to PyPI
     runs-on: ubuntu-latest
-    if: (github.event_name == 'release' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch')
+    # if: (github.event_name == 'release' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch')
     needs: [build_wheels, build_sdist]
     environment:
       name: testpypi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10"]
 
     steps:
     - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.10'
 
     - name: install python dependencies
       run: pip install build twine

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,37 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build_sdist:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: install python dependencies
+      run: pip install build twine
+
+    - name: build sdist
+      run: |
+        python -m build --sdist -o wheelhouse
+
+    - name: List and check sdist
+      run: |
+        ls -lh wheelhouse/
+        twine check wheelhouse/*
+    - name: Upload sdist
+      uses: actions/upload-artifact@v4
+      with:
+        name: sdist
+        path: ./wheelhouse/*.tar.gz
+
+
+  build_wheels:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -20,20 +50,38 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Build fairness-indicators
-      id: build-fairness-indicators
-      uses: ./.github/reusable-build
+    - name: Set up python
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        upload-artifact: true
+
+    - name: Install python build dependencies
+      run: |
+          pip install wheel
+
+    - name: Build wheels
+      run: |
+        python -m build --wheel
+        mkdir wheelhouse
+        mv dist/*.whl wheelhouse/
+    - name: List and check wheels
+      run: |
+        pip install twine pkginfo>=1.11.0
+        ${{ matrix.ls || 'ls -lh' }} wheelhouse/
+        twine check wheelhouse/*
+    - name: Upload wheels
+      uses: actions/upload-artifact@v4
+      with:
+        name: wheels-${{ matrix.python-version }}
+        path: ./wheelhouse/*.whl
 
   upload_to_pypi:
     name: Upload to PyPI
     runs-on: ubuntu-latest
     if: (github.event_name == 'release' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch')
-    needs: [build]
+    needs: [build_wheels, build_sdist]
     environment:
-      name: pypi
+      name: testpypi
       url: https://test.pypi.org/p/ajf-test-fairness-indicators
     permissions:
       id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,3 +101,4 @@ jobs:
         with:
           packages_dir: wheels/
           repository_url: https://test.pypi.org/legacy/
+          verify-metadata: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         python -m build --wheel --sdist
         mkdir wheelhouse
-        mv dist/*.whl wheelhouse/
+        mv dist/* wheelhouse/
     - name: List and check wheels
       run: |
         pip install twine pkginfo>=1.11.0
@@ -44,7 +44,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: wheels-${{ matrix.python-version }}
-        path: ./wheelhouse/*.whl
+        path: ./wheelhouse/*
 
   upload_to_pypi:
     name: Upload to PyPI

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,41 +10,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_sdist:
-    runs-on: ubuntu-latest
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Set up python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
-
-    - name: install python dependencies
-      run: pip install build twine
-
-    - name: build sdist
-      run: |
-        python -m build --sdist -o wheelhouse
-
-    - name: List and check sdist
-      run: |
-        ls -lh wheelhouse/
-        twine check wheelhouse/*
-    - name: Upload sdist
-      uses: actions/upload-artifact@v4
-      with:
-        name: sdist
-        path: ./wheelhouse/*.tar.gz
-
-
-  build_wheels:
+  build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.9", "3.10"]
 
     steps:
     - name: Checkout
@@ -57,11 +28,11 @@ jobs:
 
     - name: Install python build dependencies
       run: |
-          pip install wheel build
+          python -m pip install --upgrade pip build
 
     - name: Build wheels
       run: |
-        python -m build --wheel
+        python -m build --wheel --sdist
         mkdir wheelhouse
         mv dist/*.whl wheelhouse/
     - name: List and check wheels
@@ -79,7 +50,7 @@ jobs:
     name: Upload to PyPI
     runs-on: ubuntu-latest
     if: (github.event_name == 'release' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch')
-    needs: [build_wheels, build_sdist]
+    needs: [build]
     environment:
       name: pypi
       url: https://pypi.org/p/fairness-indicators

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Install python build dependencies
       run: |
-          pip install wheel
+          pip install wheel build
 
     - name: Build wheels
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,11 +78,11 @@ jobs:
   upload_to_pypi:
     name: Upload to PyPI
     runs-on: ubuntu-latest
-    # if: (github.event_name == 'release' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch')
+    if: (github.event_name == 'release' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch')
     needs: [build_wheels, build_sdist]
     environment:
-      name: testpypi
-      url: https://test.pypi.org/p/ajf-test-fairness-indicators
+      name: pypi
+      url: https://pypi.org/p/fairness-indicators
     permissions:
       id-token: write
     steps:
@@ -100,6 +100,6 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1.12
         with:
           packages_dir: wheels/
-          repository_url: https://test.pypi.org/legacy/
+          repository_url: https://pypi.org/legacy/
           verify_metadata: false
           verbose: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,8 +97,9 @@ jobs:
           ls -lAs wheels/
 
       - name: Upload to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.9
+        uses: pypa/gh-action-pypi-publish@release/v1.12
         with:
           packages_dir: wheels/
           repository_url: https://test.pypi.org/legacy/
           verify_metadata: false
+          verbose: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,3 +52,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1.9
         with:
           packages_dir: wheels/
+          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10"]
 
     steps:
     - name: Checkout

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ __version__ = globals_dict["__version__"]
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()
 setuptools.setup(
-    name="ajf-test-fairness-indicators",
+    name="fairness-indicators",
     version=__version__,
     description="Fairness Indicators",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ __version__ = globals_dict["__version__"]
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()
 setuptools.setup(
-    name="fairness_indicators",
+    name="ajf-test-fairness-indicators",
     version=__version__,
     description="Fairness Indicators",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ __version__ = globals_dict["__version__"]
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()
 setuptools.setup(
-    name="fairness-indicators",
+    name="fairness_indicators",
     version=__version__,
     description="Fairness Indicators",
     long_description=long_description,


### PR DESCRIPTION
Adds a CI workflow for building wheel and pushing metadata to pypi. Note that for this to work, the tensorflow/fairness-indicators repo will need to be setup as a [trusted publisher](https://docs.pypi.org/trusted-publishers/) on the relevant pypi account. 

I tested this workflow with the testpypi artifactory. You can see the results [here](https://github.com/andrewfulton9/fairness-indicators/actions/runs/15168285331) of the CI run here.

This PR also depends on and includes code from PR #390. Once that is merged, I will rebase this one.